### PR TITLE
Allow steps to be skipped

### DIFF
--- a/lib/crack_pipe/action/step.rb
+++ b/lib/crack_pipe/action/step.rb
@@ -3,17 +3,19 @@
 module CrackPipe
   class Action
     class Step
-      attr_reader :exec, :track
+      attr_reader :exec, :exec_if, :track
 
-      def initialize(exec = nil, always_pass: false, track: :default, **, &blk)
+      def initialize(exec = nil, always_pass: false, track: :default, **opts, &blk)
         if block_given?
           raise ArgumentError, '`exec` must be `nil` with a block' unless
             exec.nil?
+
           exec = blk
         end
 
         @always_pass = always_pass
         @exec = instantiate_action(exec)
+        @exec_if = opts.key?(:if) ? opts[:if] : true
         @track = track
       end
 
@@ -28,6 +30,7 @@ module CrackPipe
       # `step SomeAction.new` when nesting actions.
       def instantiate_action(obj)
         return obj.new if obj.is_a?(Class) && obj < Action
+
         obj
       end
     end

--- a/lib/crack_pipe/version.rb
+++ b/lib/crack_pipe/version.rb
@@ -2,8 +2,8 @@
 
 module CrackPipe
   MAJOR = 0
-  MINOR = 2
-  TINY  = 4
+  MINOR = 3
+  TINY  = 0
   VERSION = [MAJOR, MINOR, TINY].join('.').freeze
 
   def self.version


### PR DESCRIPTION
This helps to organize branching logic when working with nested actions and makes reusing actions as steps easier.

See also https://github.com/fundamerica/prime_trust_api/issues/1230